### PR TITLE
Make IP instances freezable

### DIFF
--- a/lib/ip/base.rb
+++ b/lib/ip/base.rb
@@ -247,6 +247,11 @@ class IP
     to_a.hash
   end
 
+  def freeze
+    mask
+    super
+  end
+
   def eql?(other)
     to_a.eql?(other.to_a)
   end

--- a/test/ip_test.rb
+++ b/test/ip_test.rb
@@ -476,6 +476,36 @@ class IPTest < Test::Unit::TestCase
     end
   end
 
+  context "freezing" do
+    setup do
+      @addr = IP.new('1.2.3.4/24@foo').freeze
+    end
+
+    should "be able to get values without a TypeError" do
+      assert_nothing_raised(TypeError) do
+        @addr.to_s
+        @addr.to_addrlen
+        @addr.to_addr
+        @addr.to_i
+        @addr.to_a
+        @addr.to_ah
+        @addr.to_hex
+        @addr.pfxlen
+        @addr.proto
+        @addr.to_irange
+        @addr.to_range
+        @addr.size
+        @addr.ctx
+        @addr.network
+        @addr.broadcast
+        @addr.mask
+        @addr.netmask
+        @addr.wildmask
+        @addr.offset
+      end
+    end
+  end
+
   context "range between two IPs" do
     should "be able to iterate" do
       r = IP.new("10.0.0.6")..IP.new("10.0.0.8")


### PR DESCRIPTION
Currently, if you freeze an instance and try to get its mask, broadcast address, network address and a bunch of other values, you'll get a TypeError because mask is saved in an instance variable.

This commit fixes that by calculating the memoized value before freezing, as advised here: http://blog.rubybestpractices.com/posts/rklemme/018-Complete_Class.html
