### PR TITLE
Ensure to_arpa works for all IP v6 addresses

### DIFF
--- a/lib/ip/base.rb
+++ b/lib/ip/base.rb
@@ -426,19 +426,26 @@ class IP
         return to_hex.scan(/..../).join(':')
       end
     end
+
+    # Returns the address broken into an array of 32 nibbles.  Useful for
+    # to_arpa and use in SPF - http://tools.ietf.org/html/rfc7208#section-7.3
+    def to_nibbles
+      to_hex.rjust(32, '0').split(//)
+    end
+
     #return the arpa version of the address for reverse DNS: http://en.wikipedia.org/wiki/Reverse_DNS_lookup
     def to_arpa
-      return self.to_addr_full.reverse.gsub(':','').split(//).join('.') + ".ip6.arpa"
+      to_nibbles.reverse.join('.') + '.ip6.arpa'
     end
 
     def ipv4_mapped?
       (@addr >> 32) == 0xffff
     end
-    
+
     def ipv4_compat?
       @addr > 1 && (@addr >> 32) == 0
     end
-    
+
     # Convert an IPv6 mapped/compat address to a V4 native address
     def native
       return self unless (ipv4_mapped? || ipv4_compat?) && (@pfxlen >= 96)

--- a/test/ip_test.rb
+++ b/test/ip_test.rb
@@ -413,6 +413,11 @@ class IPTest < Minitest::Test
       res = IP::V6.new(0xdeadbeef000000000000000000000123, 24, "foo")
       assert_equal res, res.native
     end
+
+    it 'has to_arpa' do
+      res = IP.new('dead:beef::123')
+      assert_equal '3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.b.d.a.e.d.ip6.arpa', res.to_arpa
+    end
   end
 
   describe "v6 ::0" do
@@ -427,6 +432,10 @@ class IPTest < Minitest::Test
     it "has native" do
       assert_equal @addr, @addr.native
     end
+
+    it 'has to_arpa' do
+      assert_equal '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
+    end
   end
 
   describe "v6 ::1" do
@@ -440,6 +449,10 @@ class IPTest < Minitest::Test
 
     it "has native" do
       assert_equal @addr, @addr.native
+    end
+
+    it 'has to_arpa' do
+      assert_equal '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
   end
 
@@ -461,6 +474,10 @@ class IPTest < Minitest::Test
       a2 = @addr.native
       assert_equal "1.2.3.4/24@xxx", a2.to_s
     end
+
+    it 'has to_arpa' do
+      assert_equal '4.0.3.0.2.0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
+    end
   end
 
   describe "v6 mapped" do
@@ -480,6 +497,10 @@ class IPTest < Minitest::Test
     it "has native" do
       a2 = @addr.native
       assert_equal "1.2.3.4/24@xxx", a2.to_s
+    end
+
+    it 'has to_arpa' do
+      assert_equal '4.0.3.0.2.0.1.0.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
 
     it "converts v6 addresses unambiguously" do


### PR DESCRIPTION
1. Fixed to_arpa for IP v4 mapped and compatible addresses
2. Fixed to_arpa for '::'
3. Added specs for to_arpa on IP::V6
4. Added a useful utility method (to_nibbles) that is used by to_arpa, and is useful when building SPF implementations.
