### PR TITLE
Add license to gemspec

### DIFF
--- a/ruby-ip.gemspec
+++ b/ruby-ip.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.summary = 'IP address manipulation library'
   s.homepage = 'http://github.com/deploy2/ruby-ip'
   s.description = 'IP address manipulation library'
+  s.license = 'Ruby'
 
   s.files = Dir['lib/**/*.rb'] +
             Dir['test/**/*.rb'] +


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.