### PR TITLE
Addresses can be stored in a VARBINARY(16) database column as string of bytes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -72,19 +72,18 @@ Docs:: http://deploy2.github.com/ruby-ip/
 * Advanced Subnet Operations
     sn = IP.new('192.168.0.0/24')
     ip = IP.new('192.168.0.48/32')
-    sn.split                    [#<IP::V4 192.168.0.0/25>, 
+    sn.split                    [#<IP::V4 192.168.0.0/25>,
                                 #<IP::V4 192.168.0.128/25>] (2 evenly divided subnets)
-    sn.divide_by_subnets(3)     [#<IP::V4 192.168.0.0/26>, 
-                                #<IP::V4 192.168.0.64/26>, 
-                                #<IP::V4 192.168.0.128/26>, 
+    sn.divide_by_subnets(3)     [#<IP::V4 192.168.0.0/26>,
+                                #<IP::V4 192.168.0.64/26>,
+                                #<IP::V4 192.168.0.128/26>,
                                 #<IP::V4 192.168.0.192/26>] (4 evenly divided subnets)
     #keep in mind this always takes into account a network and broadcast address
-    sn.divide_by_hosts(100)     [#<IP::V4 192.168.0.0/25>, 
+    sn.divide_by_hosts(100)     [#<IP::V4 192.168.0.0/25>,
                                 #<IP::V4 192.168.0.128/25>] (128 hosts each)
     ip = IP.new('192.168.0.48/32')
     ip.is_in?(sn)
-    => true 
-    
+    => true
 
 * Convert to and from a compact Array representation
 
@@ -104,6 +103,46 @@ Docs:: http://deploy2.github.com/ruby-ip/
     ip1 == ip2   # true
 
 * Addresses are Comparable, sortable, and can be used as Hash keys
+
+* Addresses can be stored in a VARBINARY(16) database column as string of bytes
+
+    # == Schema Information
+    #
+    # Table name: ipaddresses
+    #
+    #  id         :integer          not null, primary key
+    #  address    :binary(16)
+    #  pfxlen     :integer
+    #  created_at :datetime         not null
+    #  updated_at :datetime         not null
+    #
+    # Indexes
+    #
+    #  index_ipaddresses_on_address  (address)
+    #  index_ipaddresses_on_pfxlen   (pfxlen)
+    #
+
+    require 'ip'
+    class IpAddress < ActiveRecord::Base
+      validates_uniqueness_of :address, scope: [:pfxlen]
+      validates_presence_of :address, :pfxlen
+
+      # IpAddress.last.address returns an IP object
+      def address
+        IP.new("#{IP.new_ntoh(super).to_s}/#{pfxlen}")
+      end
+
+      # Address can be set with string:
+      # ipaddress = IpAddress.new({address: '2001:db8:be00::/128'})
+      # Or IP object:
+      # ip = IP.new('2001:db8:be00::/128')
+      # ipaddress = IpAddress.new({address: ip})
+      def address=(arg)
+        ip = IP.new(arg)
+        self.pfxlen = ip.pfxlen
+        super(ip.to_hton)
+      end
+    end
 
 == Why not IPAddr?
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -22,6 +22,20 @@ Docs:: http://deploy2.github.com/ruby-ip/
     ip.to_arpa    # "53.2.0.192.in-addr.arpa."
     ip.pfxlen     # 24
 
+* Convert from IPAddr to IP and back to IPAddr
+
+    # new IPAddr
+    ipaddr = IPAddr.new('192.168.2.1')
+    # => #<IPAddr: IPv4:192.168.2.1/255.255.255.255>
+
+    # convert it to IP
+    ip_from_ipaddr = IP.new_ntoh(ipaddr.hton)
+    # => <IP::V4 192.168.2.1>
+
+    # and back to IPAddr
+    ipaddr_from_ip = IPAddr.new_ntoh(ip_from_ipaddr.hton)
+    # => #<IPAddr: IPv4:192.168.2.1/255.255.255.255>
+
 * Qualify IP address with "routing context" (VRF)
 
     ip = IP.new("192.0.2.53/24@cust1")
@@ -140,7 +154,7 @@ Docs:: http://deploy2.github.com/ruby-ip/
       def address=(arg)
         ip = IP.new(arg)
         self.pfxlen = ip.pfxlen
-        super(ip.to_hton)
+        super(ip.hton)
       end
     end
 

--- a/lib/ip/base.rb
+++ b/lib/ip/base.rb
@@ -383,7 +383,7 @@ class IP
     end
 
     # Returns a network byte ordered string form of the IP address.
-    def to_hton
+    def hton
       [@addr].pack('N')
     end
   end
@@ -478,7 +478,7 @@ class IP
     end
 
     # Returns a network byte ordered string form of the IP address.
-    def to_hton
+    def hton
       (0..7).map { |i| (@addr >> (112 - 16 * i)) & 0xffff }.pack('n8')
     end
 

--- a/lib/ip/base.rb
+++ b/lib/ip/base.rb
@@ -64,6 +64,26 @@ class IP
     self.class::PROTO
   end
 
+  # Creates a new ip containing the given network byte ordered
+  # string form of an IP address.
+  def IP::new_ntoh(addr)
+    return IP.new(IP::ntop(addr))
+  end
+
+  # Convert a network byte ordered string form of an IP address into
+  # human readable form.
+  def IP::ntop(addr)
+    case addr.size
+    when 4
+      s = addr.unpack('C4').join('.')
+    when 16
+      s = (["%.4x"] * 8).join(':') % addr.unpack('n8')
+    else
+      fail ArgumentError, 'Invalid address value'
+    end
+    return s
+  end
+
   # Return the string representation of the address, x.x.x.x[/pfxlen][@ctx]
   def to_s
     ctx ? "#{to_addrlen}@#{ctx}" : to_addrlen
@@ -361,6 +381,11 @@ class IP
              (@addr >> 16) & 0xff,
              (@addr >> 24) & 0xff)
     end
+
+    # Returns a network byte ordered string form of the IP address.
+    def to_hton
+      [@addr].pack('N')
+    end
   end
 
   class V6 < IP
@@ -450,6 +475,11 @@ class IP
       else
         return to_hex.scan(/..../).join(':')
       end
+    end
+
+    # Returns a network byte ordered string form of the IP address.
+    def to_hton
+      (0..7).map { |i| (@addr >> (112 - 16 * i)) & 0xffff }.pack('n8')
     end
 
     # Returns the address broken into an array of 32 nibbles.  Useful for

--- a/test/ip_test.rb
+++ b/test/ip_test.rb
@@ -120,8 +120,8 @@ class IPTest < Minitest::Test
         assert_equal '4.3.2.1.in-addr.arpa.', @addr.to_arpa
       end
 
-      it 'has to_hton' do
-        assert_equal "\x01\x02\x03\x04", @addr.to_hton
+      it 'has hton' do
+        assert_equal "\x01\x02\x03\x04", @addr.hton
       end
 
       it 'has to_i' do
@@ -415,7 +415,7 @@ class IPTest < Minitest::Test
     end
 
     it 'builds from hton' do
-      hton = IP::V6.new(0xdeadbeef000000000000000000000123, 24, 'foo').to_hton
+      hton = IP::V6.new(0xdeadbeef000000000000000000000123, 24, 'foo').hton
       res = IP.new_ntoh(hton)
       assert_equal IP::V6, res.class
       assert_equal 128, res.pfxlen
@@ -448,9 +448,9 @@ class IPTest < Minitest::Test
       assert_equal '3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.b.d.a.e.d.ip6.arpa', res.to_arpa
     end
 
-    it 'has to_hton' do
+    it 'has hton' do
       res = String.new
-      IP.new('dead:beef::123').to_hton.each_byte { |c|
+      IP.new('dead:beef::123').hton.each_byte { |c|
         res += sprintf("%02x", c)
       }
       assert_equal 'deadbeef000000000000000000000123', res
@@ -474,8 +474,8 @@ class IPTest < Minitest::Test
       assert_equal '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
 
-    it 'has to_hton' do
-      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", @addr.to_hton
+    it 'has hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", @addr.hton
     end
   end
 
@@ -496,8 +496,8 @@ class IPTest < Minitest::Test
       assert_equal '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
 
-    it 'has to_hton' do
-      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", @addr.to_hton
+    it 'has hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", @addr.hton
     end
   end
 
@@ -524,8 +524,8 @@ class IPTest < Minitest::Test
       assert_equal '4.0.3.0.2.0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
 
-    it 'has to_hton' do
-      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04", @addr.to_hton
+    it 'has hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04", @addr.hton
     end
   end
 
@@ -552,9 +552,9 @@ class IPTest < Minitest::Test
       assert_equal '4.0.3.0.2.0.1.0.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
 
-    it 'has to_hton' do
+    it 'has hton' do
       assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF\x01\x02\x03\x04".force_encoding("ASCII-8BIT"),
-        @addr.to_hton
+        @addr.hton
     end
 
     it 'converts v6 addresses unambiguously' do
@@ -632,8 +632,8 @@ class IPTest < Minitest::Test
       assert_equal '4.3.2.1.in-addr.arpa.', @addr.to_arpa
     end
 
-    it 'responds to to_hton withouth a TypeError' do
-      assert_equal "\x01\x02\x03\x04", @addr.to_hton
+    it 'responds to hton withouth a TypeError' do
+      assert_equal "\x01\x02\x03\x04", @addr.hton
     end
 
     it 'responds to to_i withouth a TypeError' do

--- a/test/ip_test.rb
+++ b/test/ip_test.rb
@@ -67,6 +67,14 @@ class IPTest < Minitest::Test
       assert(s1.object_id != s2.object_id)
     end
 
+    it 'builds from hton' do
+      hton = "\x01\x02\x03\x04"
+      res = IP.new_ntoh(hton)
+      assert_equal IP::V4, res.class
+      assert_equal 32, res.pfxlen
+      assert_nil res.ctx
+    end
+
     it 'disallows invalid addr' do
       assert_raises(ArgumentError) { IP::V4.new(1 << 32) }
       assert_raises(ArgumentError) { IP::V4.new(-1) }
@@ -110,6 +118,10 @@ class IPTest < Minitest::Test
 
       it 'has to_arpa' do
         assert_equal '4.3.2.1.in-addr.arpa.', @addr.to_arpa
+      end
+
+      it 'has to_hton' do
+        assert_equal "\x01\x02\x03\x04", @addr.to_hton
       end
 
       it 'has to_i' do
@@ -402,6 +414,14 @@ class IPTest < Minitest::Test
       assert(s1.object_id != s2.object_id)
     end
 
+    it 'builds from hton' do
+      hton = IP::V6.new(0xdeadbeef000000000000000000000123, 24, 'foo').to_hton
+      res = IP.new_ntoh(hton)
+      assert_equal IP::V6, res.class
+      assert_equal 128, res.pfxlen
+      assert_nil res.ctx
+    end
+
     it 'disallows invalid addr' do
       assert_raises(ArgumentError) { IP::V6.new(1 << 128) }
       assert_raises(ArgumentError) { IP::V6.new(-1) }
@@ -427,6 +447,14 @@ class IPTest < Minitest::Test
       res = IP.new('dead:beef::123')
       assert_equal '3.2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.b.d.a.e.d.ip6.arpa', res.to_arpa
     end
+
+    it 'has to_hton' do
+      res = String.new
+      IP.new('dead:beef::123').to_hton.each_byte { |c|
+        res += sprintf("%02x", c)
+      }
+      assert_equal 'deadbeef000000000000000000000123', res
+    end
   end
 
   describe 'v6 ::0' do
@@ -445,6 +473,10 @@ class IPTest < Minitest::Test
     it 'has to_arpa' do
       assert_equal '0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
+
+    it 'has to_hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", @addr.to_hton
+    end
   end
 
   describe 'v6 ::1' do
@@ -462,6 +494,10 @@ class IPTest < Minitest::Test
 
     it 'has to_arpa' do
       assert_equal '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
+    end
+
+    it 'has to_hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", @addr.to_hton
     end
   end
 
@@ -487,6 +523,10 @@ class IPTest < Minitest::Test
     it 'has to_arpa' do
       assert_equal '4.0.3.0.2.0.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
     end
+
+    it 'has to_hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04", @addr.to_hton
+    end
   end
 
   describe 'v6 mapped' do
@@ -510,6 +550,11 @@ class IPTest < Minitest::Test
 
     it 'has to_arpa' do
       assert_equal '4.0.3.0.2.0.1.0.f.f.f.f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa', @addr.to_arpa
+    end
+
+    it 'has to_hton' do
+      assert_equal "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xFF\xFF\x01\x02\x03\x04".force_encoding("ASCII-8BIT"),
+        @addr.to_hton
     end
 
     it 'converts v6 addresses unambiguously' do
@@ -585,6 +630,10 @@ class IPTest < Minitest::Test
 
     it 'responds to to_arpa withouth a TypeError' do
       assert_equal '4.3.2.1.in-addr.arpa.', @addr.to_arpa
+    end
+
+    it 'responds to to_hton withouth a TypeError' do
+      assert_equal "\x01\x02\x03\x04", @addr.to_hton
     end
 
     it 'responds to to_i withouth a TypeError' do


### PR DESCRIPTION
This feature makes it easy to use ruby-ip with ActiveRecord models and safe IP addresses in a database column. Inspired by IPAddr.

Closes #19 
